### PR TITLE
fix(mailer): lookup templates with extension

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -3,7 +3,7 @@ import Promise from 'bluebird';
 export default class Mailer {
 
   get logger() {
-    return this.container.logger;
+    return this.container.lookup('app:logger');
   }
 
   to(data) {
@@ -19,12 +19,12 @@ export default class Mailer {
   }
 
   html(data) {
-    let template = this.container.lookup(`mailer:${ this.name }/template.html`);
+    let template = this.container.lookup(`mailer:${ this.name }/template.html.js`);
     return template ? template(data) : null;
   }
 
   text(data) {
-    let template = this.container.lookup(`mailer:${ this.name }/template.txt`);
+    let template = this.container.lookup(`mailer:${ this.name }/template.txt.js`);
     return template ? template(data) : null;
   }
 


### PR DESCRIPTION
no issue
- lookup logger from the right place
- latest denali update made container references have path extensions,
so we need to add the `.js` extension to the lookup. That way we don't
conflict with the raw templates themselves